### PR TITLE
Upgrade dependencies to latest stable versions

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [21]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="https://www.jcabi.com/logo-square.svg" width="64px" height="64px" />
+# jcabi-velocity
+
+![jcabi logo](https://www.jcabi.com/logo-square.svg)
 
 [![EO principles respected here](https://www.elegantobjects.org/badge.svg)](https://www.elegantobjects.org)
 [![DevOps By Rultor.com](https://www.rultor.com/b/jcabi/jcabi-velocity)](https://www.rultor.com/p/jcabi/jcabi-velocity)
@@ -33,6 +35,6 @@ the `master` branch, if they look correct.
 
 Please run Maven build before submitting a pull request:
 
-```
-$ mvn clean install -Pqulice
+```bash
+mvn clean install -Pqulice
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.38.0</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-velocity</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.36</version>
+      <version>1.18.46</version>
     </dependency>
     <dependency>
       <!--
@@ -82,7 +82,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.27.3</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>

--- a/src/main/java/com/jcabi/velocity/VelocityPage.java
+++ b/src/main/java/com/jcabi/velocity/VelocityPage.java
@@ -119,5 +119,4 @@ public final class VelocityPage {
         engine.init();
         return engine;
     }
-
 }

--- a/src/test/java/com/jcabi/velocity/VelocityPageTest.java
+++ b/src/test/java/com/jcabi/velocity/VelocityPageTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link VelocityPage}.
- *
  * @since 0.0.1
  */
 final class VelocityPageTest {
@@ -26,5 +25,4 @@ final class VelocityPageTest {
             )
         );
     }
-
 }

--- a/src/test/java/com/jcabi/velocity/package-info.java
+++ b/src/test/java/com/jcabi/velocity/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Velocity wrapper, tests.
- *
  * @since 0.0.1
  */
 package com.jcabi.velocity;


### PR DESCRIPTION
@yegor256

This PR brings `jcabi-velocity` up to the latest stable artifacts that the `jcabi` family already publishes, and resolves the build failures that surface when the bumps are applied together.

## Dependency changes

| dependency / parent | from | to |
| --- | --- | --- |
| `com.jcabi:jcabi` (parent POM) | 1.38.0 | 1.44.0 |
| `org.projectlombok:lombok` | 1.18.36 | 1.18.46 |
| `com.qulice:qulice-maven-plugin` | 0.25.1 | 0.27.3 |

`org.apache.velocity:velocity` is left at 1.7 — the only available stable upgrade is to the `velocity-engine-core` 2.x artifact, which has a different group/artifact id and a breaking logging API (the existing `Log4JLogChute` / `RUNTIME_LOG_LOGSYSTEM_CLASS` setup goes away). That belongs in a separate PR.

## CI matrix

Qulice 0.27.x is built with `--release 21`, so it can no longer load on JDK 11/17. The `mvn` workflow matrix is therefore narrowed to `java: [21]`, matching what `jcabi-urn` already does. `actions/checkout` and `actions/setup-java` in the same workflow were bumped to `v6` and `v5` respectively to stay consistent with the rest of the org.

## Source fixes the new qulice surfaces

Qulice 0.27.3 enables stricter checkstyle defaults than 0.25.1. Four violations were fixed in code (no suppressions added):

- `RegexpMultilineCheck` — trailing blank line above the closing brace in `VelocityPage.java` (line 121) and `VelocityPageTest.java` (line 28).
- `JavadocEmptyLineBeforeTagCheck` — empty Javadoc line before `@since` in the two `package-info.java`-style javadocs (`package-info.java` line 8, `VelocityPageTest.java` line 13).

## Markdown lint fix

`markdown-lint` is failing on `master` against the README. That is unrelated to the dependency bumps but the brief asks to fix it as well, so the README is rewritten to satisfy markdownlint defaults (top-level heading on line 1, alt text on the logo image, fenced code language, no `$` prompt).

## Local verification

```
mvn --batch-mode --errors clean install -Pqulice
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] Qulice quality check completed
[INFO] BUILD SUCCESS

markdownlint-cli2 README.md
Summary: 0 error(s)

reuse lint
Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)

yamllint .
(no output)
```

## A note on CI

GitHub is currently sitting on `action_required` for every workflow on this PR because it is the first contribution from this account on this repo (same situation as `jcabi/jcabi-immutable#80`). One "Approve and run workflows" click from a maintainer should release the full mvn × {ubuntu, windows, macos} × jdk21 matrix plus the lint workflows; the changes pass locally end-to-end, so I expect them to come back green.

## Commits

1. `Bump jcabi parent to 1.44.0, lombok to 1.18.46, qulice to 0.27.3`
2. `Switch CI matrix to Java 21 (required by qulice 0.27.x)`
3. `Drop trailing blank lines and empty Javadoc lines flagged by qulice 0.27.3`
4. `Refactor README to satisfy markdownlint defaults`
