### PR TITLE
Upgrade Apache Velocity from 1.7 to 2.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
             @see http://velocity.apache.org/
             -->
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-      <version>1.7</version>
+      <artifactId>velocity-engine-core</artifactId>
+      <version>2.4.1</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/main/java/com/jcabi/velocity/VelocityPage.java
+++ b/src/main/java/com/jcabi/velocity/VelocityPage.java
@@ -22,14 +22,12 @@ import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
  *   .set("name", "John Doe")
  *   .toString();</pre>
  *
- * <p>At the moment all logging is forwarded to LOG4J. In Velocity 2.0 there
- * will be an adapter for SLF4J and we'll use it: {@code Slf4jLogChute}.
+ * <p>Logging is forwarded to SLF4J by Apache Velocity 2.x.
  *
  * <p>The class is mutable and thread-safe.
  *
- * @see <a href="http://velocity.apache.org/engine/releases/velocity-1.7/user-guide.html">Velocity User Guide</a>
- * @see <a href="http://velocity.apache.org/engine/releases/velocity-1.7/developer-guide.html">Velocity Developer Guide</a>
- * @see <a href="http://velocity.apache.org/engine/devel/apidocs/org/apache/velocity/slf4j/Slf4jLogChute.html">Slf4jLogChute</a>
+ * @see <a href="https://velocity.apache.org/engine/2.4.1/user-guide.html">Velocity User Guide</a>
+ * @see <a href="https://velocity.apache.org/engine/2.4.1/developer-guide.html">Velocity Developer Guide</a>
  * @since 0.1.6
  */
 @SuppressWarnings("PMD.AvoidSynchronizedStatement")
@@ -103,18 +101,10 @@ public final class VelocityPage {
      */
     private static VelocityEngine init() {
         final VelocityEngine engine = new VelocityEngine();
-        engine.setProperty("resource.loader", "cp");
+        engine.setProperty(RuntimeConstants.RESOURCE_LOADERS, "cp");
         engine.setProperty(
-            "cp.resource.loader.class",
+            "resource.loader.cp.class",
             ClasspathResourceLoader.class.getName()
-        );
-        engine.setProperty(
-            RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS,
-            "org.apache.velocity.runtime.log.Log4JLogChute"
-        );
-        engine.setProperty(
-            "runtime.log.logsystem.log4j.logger",
-            "org.apache.velocity"
         );
         engine.init();
         return engine;


### PR DESCRIPTION
@yegor256 this PR upgrades Apache Velocity from the long-abandoned `org.apache.velocity:velocity:1.7` to the maintained `org.apache.velocity:velocity-engine-core:2.4.1` (the current stable release). It is the only outdated dependency in `pom.xml` after the recent renovate updates; everything else (jcabi parent 1.44.0, lombok 1.18.46, qulice 0.27.5) was already on the latest stable.

## What changed

- `pom.xml`: replace `org.apache.velocity:velocity:1.7` with `org.apache.velocity:velocity-engine-core:2.4.1`.
- `VelocityPage.java`:
  - switch to the Velocity 2.x property names: `RuntimeConstants.RESOURCE_LOADERS` (`resource.loaders`) and `resource.loader.cp.class`;
  - drop the obsolete `Log4JLogChute` configuration and the `runtime.log.logsystem.log4j.logger` property — Velocity 2.x logs through SLF4J directly;
  - update the Javadoc reference to the Velocity 2.4.1 user/developer guides; the old TODO about “when Velocity 2.0 ships, switch to SLF4J” is now satisfied.

## Verification

Ran locally with the same command as CI:

```bash
mvn --errors --batch-mode clean install -Pqulice
```

Result: build, the existing `VelocityPageTest` and qulice 0.27.5 (checkstyle / PMD / findbugs / dependency / duplicate-finder etc.) all pass on JDK 21. CI on this PR — mvn on Ubuntu / macOS / Windows plus actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint — is green across all 11 jobs.

Ready for merge whenever you have a moment.