### PR TITLE
Bump qulice-maven-plugin to 0.27.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.5</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>


### PR DESCRIPTION
@yegor256 this PR upgrades the only direct dependency in this repo that was behind its latest stable release.

## Changes

- `com.qulice:qulice-maven-plugin`: **0.27.5 → 0.27.6** (latest stable on Maven Central)

All other directly-declared dependencies in `pom.xml` were already at their latest stable versions:
- `org.projectlombok:lombok` 1.18.46 (latest)
- `org.apache.velocity:velocity-engine-core` 2.4.1 (latest)
- parent `com.jcabi:jcabi` 1.44.0 (latest)

## Verification

- Local `mvn --errors --batch-mode clean install -Pqulice` passes (Java 21).
- All 11 CI checks are green: `mvn` on ubuntu-24.04 / macos-15 / windows-2022, plus actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint.
- No code changes were required to satisfy the new qulice version — no new warnings, no suppressions added.

Ready for merge.